### PR TITLE
Added schedule CRUD endpoints and a fetch endpoint for audioFiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.project
 /.settings/*
 /target/*
+/target/

--- a/src/main/java/com/followapp/core/api/AudioFileController.java
+++ b/src/main/java/com/followapp/core/api/AudioFileController.java
@@ -1,0 +1,23 @@
+package com.followapp.core.api;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import com.followapp.core.data.AudioFileRepository;
+import com.followapp.core.model.AudioFile;
+
+@Controller
+@RequestMapping(path = "/audioFiles")
+public class AudioFileController {
+	
+	@Autowired
+	private AudioFileRepository audioFileRepository;
+	
+	@GetMapping(("/all"))
+	public @ResponseBody Iterable<AudioFile> getAllAudioFiles() {
+		return audioFileRepository.getAllAudioFiles();
+	}
+}

--- a/src/main/java/com/followapp/core/api/ScheduleController.java
+++ b/src/main/java/com/followapp/core/api/ScheduleController.java
@@ -1,0 +1,55 @@
+package com.followapp.core.api;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import com.followapp.core.data.ScheduleRepository;
+import com.followapp.core.model.Schedule;
+
+@Controller
+@RequestMapping(path = "/schedule")
+public class ScheduleController {
+
+	@Autowired
+	private ScheduleRepository scheduleRepository;
+	
+	@GetMapping(("/all"))
+	public @ResponseBody Iterable<Schedule> getAllSchedules() {
+		return scheduleRepository.getAllSchedules();
+	}
+
+	@GetMapping(("/all/{type}"))
+	public @ResponseBody Iterable<Schedule> getSchedules(@PathVariable String type) {
+		return scheduleRepository.getSchedules(type);
+	}
+
+	@GetMapping("/{id}")
+	public @ResponseBody Optional<Schedule> getScheduleById(@PathVariable Integer id) {
+		return Optional.ofNullable(scheduleRepository.getScheduleById(id));
+	}
+
+	@PostMapping(path = "/create")
+	public @ResponseBody Optional<Schedule> createSchedule(@RequestBody Schedule newSchedule) {
+		return Optional.ofNullable(scheduleRepository.createNewSchedule(newSchedule));
+	}
+	
+	@PostMapping(path = "/update/{id}")
+	public @ResponseBody Optional<Schedule> updateSchedule(@RequestBody Schedule newSchedule) {
+		return Optional.ofNullable(scheduleRepository.createNewSchedule(newSchedule));
+	}
+	
+	@DeleteMapping("/{id}")
+    public @ResponseBody String deleteSchedule(@PathVariable Integer id) {
+		scheduleRepository.deleteScheduleById(id);
+        return "Deleted " + id;
+    }
+}

--- a/src/main/java/com/followapp/core/api/ScheduleController.java
+++ b/src/main/java/com/followapp/core/api/ScheduleController.java
@@ -43,8 +43,8 @@ public class ScheduleController {
 	}
 	
 	@PostMapping(path = "/update/{id}")
-	public @ResponseBody Optional<Schedule> updateSchedule(@RequestBody Schedule newSchedule) {
-		return Optional.ofNullable(scheduleRepository.createNewSchedule(newSchedule));
+	public @ResponseBody Optional<Schedule> updateSchedule(@RequestBody Schedule newSchedule,@PathVariable Integer id) {
+		return Optional.ofNullable(scheduleRepository.updateSchedule(id,newSchedule));
 	}
 	
 	@DeleteMapping("/{id}")

--- a/src/main/java/com/followapp/core/data/AudioFileRepository.java
+++ b/src/main/java/com/followapp/core/data/AudioFileRepository.java
@@ -1,0 +1,35 @@
+package com.followapp.core.data;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.simple.SimpleJdbcCall;
+import org.springframework.stereotype.Repository;
+
+import com.followapp.core.model.AudioFile;
+
+@Repository
+public class AudioFileRepository {
+	
+	@Autowired
+	NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+	@Autowired
+	JdbcTemplate jdbcTemplate;
+	
+	public Iterable<AudioFile> getAllAudioFiles() {
+		SimpleJdbcCall simpleJdbcCall = new SimpleJdbcCall(jdbcTemplate).withProcedureName("GET_AUDIO_FILES")
+				.returningResultSet("audioFiles", BeanPropertyRowMapper.newInstance(AudioFile.class));
+
+		Map<String, Object> simpleJdbcCallResult = simpleJdbcCall.execute();
+
+		@SuppressWarnings("unchecked")
+		List<AudioFile> allAudioFiles = (List<AudioFile>) simpleJdbcCallResult.get("audioFiles");
+
+		return allAudioFiles;
+	}
+}

--- a/src/main/java/com/followapp/core/data/ScheduleRepository.java
+++ b/src/main/java/com/followapp/core/data/ScheduleRepository.java
@@ -18,8 +18,6 @@ import com.followapp.core.model.Schedule;
 @Repository
 public class ScheduleRepository {
 
-	private static final String SQL_SOFT_DELETE_SCHEDULE = "UPDATE schedules set delete_flag=1 WHERE ID = :id";
-
 	@Autowired
 	NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 

--- a/src/main/java/com/followapp/core/data/ScheduleRepository.java
+++ b/src/main/java/com/followapp/core/data/ScheduleRepository.java
@@ -93,7 +93,7 @@ public class ScheduleRepository {
 
 	public Schedule updateSchedule(Integer scheduleId, Schedule newSchedule) {
 
-		SimpleJdbcCall simpleJdbcCall = new SimpleJdbcCall(jdbcTemplate).withProcedureName("SP_CREATE_SCHEDULE")
+		SimpleJdbcCall simpleJdbcCall = new SimpleJdbcCall(jdbcTemplate).withProcedureName("SP_UPDATE_SCHEDULE")
 				.returningResultSet("schedules", BeanPropertyRowMapper.newInstance(Schedule.class));
 
 		Map<String, Object> inParamMap = new HashMap<String, Object>();

--- a/src/main/java/com/followapp/core/data/ScheduleRepository.java
+++ b/src/main/java/com/followapp/core/data/ScheduleRepository.java
@@ -1,0 +1,130 @@
+package com.followapp.core.data;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.core.simple.SimpleJdbcCall;
+import org.springframework.stereotype.Repository;
+
+import com.followapp.core.model.Schedule;
+
+@Repository
+public class ScheduleRepository {
+
+	private static final String SQL_SOFT_DELETE_SCHEDULE = "UPDATE schedules set delete_flag=1 WHERE ID = :id";
+
+	@Autowired
+	NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+	@Autowired
+	JdbcTemplate jdbcTemplate;
+
+	public Iterable<Schedule> getAllSchedules() {
+		SimpleJdbcCall simpleJdbcCall = new SimpleJdbcCall(jdbcTemplate).withProcedureName("GET_ALL_SCHEDULES")
+				.returningResultSet("schedules", BeanPropertyRowMapper.newInstance(Schedule.class));
+
+		Map<String, Object> simpleJdbcCallResult = simpleJdbcCall.execute();
+
+		@SuppressWarnings("unchecked")
+		List<Schedule> allSchedules = (List<Schedule>) simpleJdbcCallResult.get("schedules");
+
+		return allSchedules;
+	}
+
+	public Iterable<Schedule> getSchedules(String scheduleType) {
+		SimpleJdbcCall simpleJdbcCall = new SimpleJdbcCall(jdbcTemplate).withProcedureName("GET_SCHEDULES")
+				.returningResultSet("schedules", BeanPropertyRowMapper.newInstance(Schedule.class));
+
+		Map<String, Object> inParamMap = new HashMap<String, Object>();
+		inParamMap.put("scheduleType", scheduleType);
+		SqlParameterSource inP = new MapSqlParameterSource(inParamMap);
+
+		Map<String, Object> simpleJdbcCallResult = simpleJdbcCall.execute(inP);
+
+		@SuppressWarnings("unchecked")
+		List<Schedule> schedules = (List<Schedule>) simpleJdbcCallResult.get("schedules");
+
+		return schedules;
+	}
+
+	public Schedule getScheduleById(Integer id) {
+		SimpleJdbcCall simpleJdbcCall = new SimpleJdbcCall(jdbcTemplate).withProcedureName("GET_SCHEDULE")
+				.returningResultSet("schedules", BeanPropertyRowMapper.newInstance(Schedule.class));
+
+		Map<String, Object> inParamMap = new HashMap<String, Object>();
+		inParamMap.put("scheduleId", id);
+		SqlParameterSource inP = new MapSqlParameterSource(inParamMap);
+
+		Map<String, Object> simpleJdbcCallResult = simpleJdbcCall.execute(inP);
+
+		@SuppressWarnings("unchecked")
+		List<Schedule> schedules = (List<Schedule>) simpleJdbcCallResult.get("schedules");
+
+		return schedules.size() > 0 ? schedules.get(0) : null;
+	}
+
+	public Schedule createNewSchedule(Schedule newSchedule) {
+
+		SimpleJdbcCall simpleJdbcCall = new SimpleJdbcCall(jdbcTemplate).withProcedureName("SP_CREATE_SCHEDULE")
+				.returningResultSet("schedules", BeanPropertyRowMapper.newInstance(Schedule.class));
+
+		Map<String, Object> inParamMap = new HashMap<String, Object>();
+		inParamMap.put("groupId", newSchedule.getGroupId());
+		inParamMap.put("actionType", newSchedule.getActionType());
+		inParamMap.put("description", newSchedule.getDescription());
+		inParamMap.put("executeTime", newSchedule.getExecuteTime());
+		inParamMap.put("audio_file_id", newSchedule.getAudioFileId());
+		inParamMap.put("sms_content_id", newSchedule.getSmsContentId());
+		inParamMap.put("smsText", newSchedule.getSmsText());
+		inParamMap.put("smsLanguage", newSchedule.getSmsLanguage());
+		SqlParameterSource inP = new MapSqlParameterSource(inParamMap);
+
+		Map<String, Object> simpleJdbcCallResult = simpleJdbcCall.execute(inP);
+		@SuppressWarnings("unchecked")
+		List<Schedule> schedules = (List<Schedule>) simpleJdbcCallResult.get("schedules");
+
+		return schedules.size() > 0 ? schedules.get(0) : null;
+	}
+
+	public Schedule updateSchedule(Integer scheduleId, Schedule newSchedule) {
+
+		SimpleJdbcCall simpleJdbcCall = new SimpleJdbcCall(jdbcTemplate).withProcedureName("SP_CREATE_SCHEDULE")
+				.returningResultSet("schedules", BeanPropertyRowMapper.newInstance(Schedule.class));
+
+		Map<String, Object> inParamMap = new HashMap<String, Object>();
+		inParamMap.put("scheduleId", scheduleId);
+		inParamMap.put("groupId", newSchedule.getGroupId());
+		inParamMap.put("actionType", newSchedule.getActionType());
+		inParamMap.put("description", newSchedule.getDescription());
+		inParamMap.put("executeTime", newSchedule.getExecuteTime());
+		inParamMap.put("audio_file_id", newSchedule.getAudioFileId());
+		inParamMap.put("sms_content_id", newSchedule.getSmsContentId());
+		inParamMap.put("smsText", newSchedule.getSmsText());
+		inParamMap.put("smsLanguage", newSchedule.getSmsLanguage());
+		SqlParameterSource inP = new MapSqlParameterSource(inParamMap);
+
+		Map<String, Object> simpleJdbcCallResult = simpleJdbcCall.execute(inP);
+		@SuppressWarnings("unchecked")
+		List<Schedule> schedules = (List<Schedule>) simpleJdbcCallResult.get("schedules");
+
+		return schedules.size() > 0 ? schedules.get(0) : null;
+	}
+	
+	public void deleteScheduleById(Integer scheduleId) {
+		SimpleJdbcCall simpleJdbcCall = new SimpleJdbcCall(jdbcTemplate).withProcedureName("DELETE_SCHEDULE")
+				.returningResultSet("schedules", BeanPropertyRowMapper.newInstance(Schedule.class));
+
+		Map<String, Object> inParamMap = new HashMap<String, Object>();
+		inParamMap.put("scheduleId", scheduleId);
+		SqlParameterSource inP = new MapSqlParameterSource(inParamMap);
+		simpleJdbcCall.execute(inP);
+	}
+
+}

--- a/src/main/java/com/followapp/core/model/AudioFile.java
+++ b/src/main/java/com/followapp/core/model/AudioFile.java
@@ -1,0 +1,64 @@
+package com.followapp.core.model;
+
+import java.time.LocalDateTime;
+
+public class AudioFile {
+	private int id;
+	private String name;
+	private String relativePath;
+	private String metadata;
+	private Boolean deleteFlag;
+	private LocalDateTime createdDateTime;
+	private LocalDateTime updatedDateTime;
+	
+		public int getId() {
+		return id;
+	}
+	public void setId(int id) {
+		this.id = id;
+	}
+	public String getName() {
+		return name;
+	}
+	public void setName(String name) {
+		this.name = name;
+	}
+	public String getRelativePath() {
+		return relativePath;
+	}
+	public void setRelativePath(String relativePath) {
+		this.relativePath = relativePath;
+	}
+	public String getMetadata() {
+		return metadata;
+	}
+	public void setMetadata(String metadata) {
+		this.metadata = metadata;
+	}
+	public Boolean getDeleteFlag() {
+		return deleteFlag;
+	}
+	public void setDeleteFlag(Boolean deleteFlag) {
+		this.deleteFlag = deleteFlag;
+	}
+	public LocalDateTime getCreatedDateTime() {
+		return createdDateTime;
+	}
+	public void setCreatedDateTime(LocalDateTime createdDateTime) {
+		this.createdDateTime = createdDateTime;
+	}
+	public LocalDateTime getUpdatedDateTime() {
+		return updatedDateTime;
+	}
+	public void setUpdatedDateTime(LocalDateTime updatedDateTime) {
+		this.updatedDateTime = updatedDateTime;
+	}
+	
+	@Override
+	public String toString() {
+		return "AudioFile [id=" + id + ", name=" + name + ", relativePath=" + relativePath + ", metadata=" + metadata
+				+ ", deleteFlag=" + deleteFlag + ", createdDateTime=" + createdDateTime + ", updatedDateTime="
+				+ updatedDateTime + "]";
+	}
+	
+}

--- a/src/main/java/com/followapp/core/model/Schedule.java
+++ b/src/main/java/com/followapp/core/model/Schedule.java
@@ -5,11 +5,15 @@ import java.time.LocalDateTime;
 public class Schedule {
     private Integer scheduleId;
     private Integer groupId;
+    private String groupName;
     private String description;
     private LocalDateTime executeTime;
     private ActionType actionType;
     private Integer audioFileId;
     private Integer smsContentId;
+    private String smsText;
+    private String smsLanguage;
+    private String audioFileName;
     private String status;
     private Boolean deleteFlag;
     private LocalDateTime createdDateTime;
@@ -58,7 +62,7 @@ public class Schedule {
     public Integer getAudioFileId() {
         return audioFileId;
     }
-
+    
     public void setAudioFileId(Integer audioFileId) {
         this.audioFileId = audioFileId;
     }
@@ -108,11 +112,15 @@ public class Schedule {
         final StringBuffer sb = new StringBuffer("Schedule{");
         sb.append("scheduleId=").append(scheduleId);
         sb.append(", groupId=").append(groupId);
+        sb.append(", groupName=").append(groupName);
         sb.append(", description='").append(description).append('\'');
         sb.append(", executeTime=").append(executeTime);
         sb.append(", actionType=").append(actionType);
         sb.append(", audioFileId=").append(audioFileId);
+        sb.append(", audioFileName=").append(audioFileName);
         sb.append(", smsContentId=").append(smsContentId);
+        sb.append(", smsText=").append(smsText);
+        sb.append(", smsLanguage=").append(smsLanguage);
         sb.append(", status='").append(status).append('\'');
         sb.append(", deleteFlag=").append(deleteFlag);
         sb.append(", createdDateTime=").append(createdDateTime);
@@ -120,4 +128,36 @@ public class Schedule {
         sb.append('}');
         return sb.toString();
     }
+
+	public String getSmsText() {
+		return smsText;
+	}
+
+	public void setSmsText(String smsText) {
+		this.smsText = smsText;
+	}
+
+	public String getSmsLanguage() {
+		return smsLanguage;
+	}
+
+	public void setSmsLanguage(String smsLanguage) {
+		this.smsLanguage = smsLanguage;
+	}
+
+	public String getAudioFileName() {
+		return audioFileName;
+	}
+
+	public void setAudioFileName(String audioFileName) {
+		this.audioFileName = audioFileName;
+	}
+
+	public String getGroupName() {
+		return groupName;
+	}
+
+	public void setGroupName(String groupName) {
+		this.groupName = groupName;
+	}
 }

--- a/src/main/java/com/followapp/core/model/SmsLanguage.java
+++ b/src/main/java/com/followapp/core/model/SmsLanguage.java
@@ -4,7 +4,12 @@ import java.util.Arrays;
 
 public enum SmsLanguage {
     ENGLISH,
-    HINDI;
+    HINDI,
+	MARATHI,
+	TAMIL,
+	URDU,
+	KANNADA,
+	GUJRATHI;
 
     public static SmsLanguage find(String value) {
         return Arrays.asList(values()).stream().filter(smsLanguage -> smsLanguage.name().equalsIgnoreCase(value))


### PR DESCRIPTION
1. Added following endpoints for manipulating schedules
  - GET /schedule/all -> fetch all schedules
  - GET /schedule/all/{type} -> fetch schedules by type (SMS/CALL)
  - GET /schedule/{id} -> fetch schedule by id
  - POST /schedule/create
  - POST /schedule/update/{id} 
  - DELETE /schedule/{id} 
2. Added fetch endpoint for audio files
  - GET /audioFiles/all
3. Updated SMSLanguage enum to add the following languages : MARATHI, TAMIL, URDU, KANNADA, GUJRATHI.

Sample input for POST /schedule/* endpoints:
`{"groupId":4,"description":"Testing schedule","executeTime":"2020-06-03T00:00:00","actionType":"SMS","smsContentId":null,"smsText":"blah blah... ","smsLanguage":"ENGLISH"}` 


